### PR TITLE
Update pre-start

### DIFF
--- a/jobs/uaa/templates/pre-start
+++ b/jobs/uaa/templates/pre-start
@@ -42,7 +42,9 @@ function process_certs {
 }
 
 if [ -a $CERT_CACHE_FILE ] && [ -a $TRUST_STORE_FILE ]; then
+    set +e
     diff $CERT_CACHE_FILE $CERT_FILE >/dev/null
+    set -e
     if [ $? -eq 0 ]; then
       echo "No changes to CA certificates. Will not build Java keystore file."
     else


### PR DESCRIPTION
If the `diff` cmd at line 46 finds a difference between the 2 files it returns 1 and, therefore, as `set -e` is enabled the script will exit.
This fixes the aforementioned issue.